### PR TITLE
Create logging utilities + integrate firebase crashlytics

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,16 +3,20 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
+apply plugin: 'com.google.gms.google-services'
+apply plugin: 'com.google.firebase.crashlytics'
+
 android {
   compileSdkVersion 29
   buildToolsVersion "29.0.2"
 
   defaultConfig {
     applicationId "me.emmarivera.weather"
-    minSdkVersion 15
+    minSdkVersion 16
     targetSdkVersion 29
     versionCode 1
     versionName "1.0"
+    multiDexEnabled true
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }
 
@@ -41,16 +45,24 @@ android {
 }
 
 dependencies {
-  implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+  implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
-  // Ui libraries
+  // Android libraries
   implementation 'androidx.appcompat:appcompat:1.1.0'
   implementation 'androidx.core:core-ktx:1.1.0'
+  implementation 'androidx.multidex:multidex:2.0.1'
   implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
   implementation 'com.google.android.material:material:1.1.0-rc02'
 
   // Ui utility libraries
   implementation 'com.jakewharton.rxbinding2:rxbinding:2.2.0'
+
+  // Android lifecycle libraries
+  def lifecycleVersion = "2.2.0"
+  implementation "androidx.lifecycle:lifecycle-extensions:$lifecycleVersion"
+  implementation "androidx.lifecycle:lifecycle-common-java8:$lifecycleVersion"
+  implementation "androidx.lifecycle:lifecycle-runtime:$lifecycleVersion"
+  implementation "androidx.lifecycle:lifecycle-process:$lifecycleVersion"
 
   // Dependency injection
   def daggerVersion = "2.25.4"
@@ -84,6 +96,10 @@ dependencies {
   implementation "io.reactivex.rxjava2:rxkotlin:2.4.0"
   implementation "io.reactivex.rxjava2:rxandroid:2.1.1"
   implementation "com.jakewharton.timber:timber:4.7.1"
+
+  // Firebase libraries
+  implementation 'com.google.firebase:firebase-analytics:17.2.2'
+  implementation 'com.google.firebase:firebase-crashlytics:17.0.0-beta01'
 
   // Testing libraries
   testImplementation "junit:junit:4.12"

--- a/app/google-services.json
+++ b/app/google-services.json
@@ -1,0 +1,40 @@
+{
+  "project_info": {
+    "project_number": "822602608135",
+    "firebase_url": "https://emma-weather.firebaseio.com",
+    "project_id": "emma-weather",
+    "storage_bucket": "emma-weather.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:822602608135:android:0bcbe6a854cb45407544a2",
+        "android_client_info": {
+          "package_name": "me.emmarivera.weather"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "822602608135-ocarhhru05r4g286531q80kdfp8sv4k7.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyCfy0EdRtI0cxV3FfxA_TmKVHwZjWELQy0"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "822602608135-ocarhhru05r4g286531q80kdfp8sv4k7.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/app/src/main/java/me/emmarivera/weather/AppInjection.kt
+++ b/app/src/main/java/me/emmarivera/weather/AppInjection.kt
@@ -2,9 +2,12 @@ package me.emmarivera.weather
 
 import android.app.Application
 import android.content.Context
+import com.google.firebase.analytics.FirebaseAnalytics
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import dagger.Binds
 import dagger.Component
 import dagger.Module
+import dagger.Provides
 import dagger.android.AndroidInjectionModule
 import dagger.android.AndroidInjector
 import dagger.android.ContributesAndroidInjector
@@ -15,6 +18,9 @@ import me.emmarivera.weather.internal.AppScope
 import me.emmarivera.weather.feature.splash.SplashModule
 import me.emmarivera.weather.feature.splash.view.SplashActivity
 
+/**
+ * Tells Dagger2 how to inject application specific items the @AppScope
+ */
 @Module
 abstract class AppModule {
 
@@ -27,6 +33,23 @@ abstract class AppModule {
   abstract fun appContext(app: WeatherApp): Context
 }
 
+/**
+ * Tells Dagger2 how to inject all the Firebase classes we use.
+ */
+@Module
+class FirebaseModule {
+  @Provides
+  @AppScope
+  fun crashlytics(): FirebaseCrashlytics = FirebaseCrashlytics.getInstance()
+
+  @Provides
+  @AppScope
+  fun analytics(context: Context): FirebaseAnalytics = FirebaseAnalytics.getInstance(context)
+}
+
+/**
+ * Tells Dagger2 to hook-up injection *magically* for our activities
+ */
 @Module
 abstract class ActivityInjectorModule {
 
@@ -39,12 +62,16 @@ abstract class ActivityInjectorModule {
   abstract fun homeActivity(): HomeActivity
 }
 
+/**
+ * Tells Dagger2 what modules are used in our application scope.
+ */
 @AppScope
 @Component(modules = [
   AndroidInjectionModule::class,
   AndroidSupportInjectionModule::class,
   AppModule::class,
-  ActivityInjectorModule::class
+  ActivityInjectorModule::class,
+  FirebaseModule::class
 ])
 interface AppComponent : AndroidInjector<WeatherApp> {
 

--- a/app/src/main/java/me/emmarivera/weather/feature/splash/presenter/SplashPresenterImpl.kt
+++ b/app/src/main/java/me/emmarivera/weather/feature/splash/presenter/SplashPresenterImpl.kt
@@ -5,7 +5,7 @@ import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
 import io.reactivex.rxkotlin.subscribeBy
 import me.emmarivera.weather.internal.ActivityScope
-import me.emmarivera.weather.internal.Loggable
+import me.emmarivera.weather.internal.logging.Loggable
 import me.emmarivera.weather.feature.splash.view.SplashView
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject

--- a/app/src/main/java/me/emmarivera/weather/feature/splash/view/SplashActivity.kt
+++ b/app/src/main/java/me/emmarivera/weather/feature/splash/view/SplashActivity.kt
@@ -5,11 +5,12 @@ import android.os.Bundle
 import dagger.android.support.DaggerAppCompatActivity
 import me.emmarivera.weather.feature.HomeActivity
 import me.emmarivera.weather.R
-import me.emmarivera.weather.internal.Loggable
+import me.emmarivera.weather.internal.logging.Loggable
 import me.emmarivera.weather.feature.splash.presenter.SplashPresenter
 import javax.inject.Inject
 
-class SplashActivity : DaggerAppCompatActivity(), SplashView, Loggable {
+class SplashActivity : DaggerAppCompatActivity(), SplashView,
+  Loggable {
   override val logTag: String = "splash-activity"
 
   @Inject lateinit var presenter: SplashPresenter

--- a/app/src/main/java/me/emmarivera/weather/internal/logging/ActivityLifecycleLogger.kt
+++ b/app/src/main/java/me/emmarivera/weather/internal/logging/ActivityLifecycleLogger.kt
@@ -1,0 +1,32 @@
+package me.emmarivera.weather.internal.logging
+
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
+import me.emmarivera.weather.internal.AppScope
+import timber.log.Timber
+import javax.inject.Inject
+
+/**
+ * Logs out the activity lifecycle events using timber.
+ */
+@AppScope
+class ActivityLifecycleLogger @Inject constructor() : Application.ActivityLifecycleCallbacks {
+
+  private fun log(activity: Activity, state: String) = when (activity) {
+    is Loggable -> activity.logger.i(state)
+    else -> Timber.tag(activity::class.java.simpleName).i(state)
+  }
+
+  override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) =
+    log(activity, "onCreate()")
+
+  override fun onActivityStarted(activity: Activity) = log(activity, "onStart()")
+  override fun onActivityResumed(activity: Activity) = log(activity, "onResume()")
+  override fun onActivityPaused(activity: Activity) = log(activity, "onPause()")
+  override fun onActivityStopped(activity: Activity) = log(activity, "onStopped()")
+  override fun onActivityDestroyed(activity: Activity) = log(activity, "onDestroyed()")
+
+  override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) =
+    log(activity, "onSaveInstanceState()")
+}

--- a/app/src/main/java/me/emmarivera/weather/internal/logging/CrashlyticsTree.kt
+++ b/app/src/main/java/me/emmarivera/weather/internal/logging/CrashlyticsTree.kt
@@ -1,0 +1,49 @@
+package me.emmarivera.weather.internal.logging
+
+import android.util.Log
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import me.emmarivera.weather.internal.AppScope
+import timber.log.Timber
+import java.io.PrintWriter
+import java.io.StringWriter
+import javax.inject.Inject
+
+/**
+ * Used in release builds to send runtime-crashes to firebase crashlytics.
+ */
+@AppScope
+class CrashlyticsTree @Inject constructor(
+  private val crashlytics: FirebaseCrashlytics
+) : Timber.Tree() {
+
+  private fun getTag(tag: String?) = "${tag ?: "unknown"}:"
+
+  private fun stacktraceFrom(throwable: Throwable): String {
+    val stringWriter = StringWriter()
+    throwable.printStackTrace(PrintWriter(stringWriter))
+    return stringWriter.toString()
+  }
+
+  private fun formatNormalMessage(message: String, throwable: Throwable?): String {
+    if (throwable == null) return message
+
+    return "$message\n${stacktraceFrom(throwable)}"
+  }
+
+  override fun log(
+    priority: Int,
+    tag: String?,
+    message: String,
+    t: Throwable?
+  ) {
+    when (priority) {
+      Log.INFO, Log.VERBOSE, Log.WARN -> crashlytics.log(
+        "${getTag(tag)} ${formatNormalMessage(message, t)}"
+      )
+      Log.ERROR, Log.ASSERT -> {
+        crashlytics.log("${getTag(tag)} $message")
+        if (t != null) crashlytics.recordException(t)
+      }
+    }
+  }
+}

--- a/app/src/main/java/me/emmarivera/weather/internal/logging/Loggable.kt
+++ b/app/src/main/java/me/emmarivera/weather/internal/logging/Loggable.kt
@@ -1,4 +1,4 @@
-package me.emmarivera.weather.internal
+package me.emmarivera.weather.internal.logging
 
 import timber.log.Timber
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,8 @@ buildscript {
   dependencies {
     classpath 'com.android.tools.build:gradle:3.5.3'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    // NOTE: Do not place your application dependencies here; they belong
-    // in the individual module build.gradle files
+    classpath 'com.google.gms:google-services:4.3.3'
+    classpath 'com.google.firebase:firebase-crashlytics-gradle:2.0.0-beta01'
   }
 }
 


### PR DESCRIPTION
* Create ActivityLifecycleLogger that logs all activity lifecycle methods.
* Setup crashlytics to enable runtime crash-reporting
* Created CrashlyticsTree that is swapped out for runtime builds so logs go to crashlytics.
* Moved logging libraries -> `.internal.logging`

Related Issues: #7 